### PR TITLE
Update get-random-page.md

### DIFF
--- a/get-random-page.md
+++ b/get-random-page.md
@@ -22,14 +22,12 @@ You have a pool of pages, e.g. quotes/testimonials, and want to display a random
 solution:
 A little example how to pull a random page:
 ```PHP
-$quote = $pages->find("parent=1041, include=hidden"); // example parent
+$quote = $pages->find("template=quote, include=hidden, sort=random, limit=1")->first();
 
-if(count($quote)) {
+if($quote->id) {
 
-	$quote->shuffle();
-	$pick = $quote->getRandom();
-	$q = $pick->quote; // example field
-	$a = $pick->author; // example field
+	$q = $quote->quote; // example field
+	$a = $quote->author; // example field
 
 	echo "<div class='quoteWrapper'>\n";
 	echo "	<div class='quote'>$q</div>\n";

--- a/get-random-page.md
+++ b/get-random-page.md
@@ -2,7 +2,7 @@ title: Get random page via API, e.g. from a pool of testimonials
 
 ----
 
-version: 0.0.2
+version: 0.0.3
 
 ----
 


### PR DESCRIPTION
Old code had few problems:

$quote = $pages->find("parent=1041, include=hidden"); // example parent
 - using parent id is not nice for code readability
 - this loads all quotes - will lead into performance/memory problems when you got thousands of quotes

Also unnecessary to shuffle before getting random:
$quote->shuffle();
	$pick = $quote->getRandom();