### PR TITLE
prefill PageTable fields with children on edit.md

### DIFF
--- a/prefill PageTable fields with children on edit.md
+++ b/prefill PageTable fields with children on edit.md
@@ -1,0 +1,51 @@
+I use a PageTable field to make edits to children of pages more intuitive…
+
+To register the hooks, insert the following Snippet inside your init function in your module (or add it to your init.php file):
+
+    /**
+     * Initialize the module.
+     *
+     * ProcessWire calls this when the module is loaded. For 'autoload' modules, this will be called
+     * when ProcessWire's API is ready. As a result, this is a good place to attach hooks.
+     */
+    public function init()
+    {
+      // Prefill pageTable field
+      $this->wire()->addHookBefore('InputfieldPageTable::render', $this, 'addChildrenToPageTableFieldsHook');
+      $this->wire()->addHookBefore('InputfieldPageTableAjax::checkAjax', $this, 'addChildrenToPageTableFieldsHook');
+    }
+
+Then, add this hook method:
+
+      /**
+       * Fill pagetable fields with children before editing….
+       *
+       * @param HookEvent $event
+       */
+      public function addChildrenToPageTableFieldsHook(HookEvent $event)
+      {
+        $field = $event->object;
+
+        // on ajax, the first hook has no fieldname
+        if (!$field->name) {
+          return;
+        }
+
+        // get the edited backend page
+        $editID = $this->wire('input')->get->int('id');
+        if (!$editID && $this->wire('process') instanceof WirePageEditor) {
+          $editID = $this->wire('process')->getPage()->id;
+        }
+        $page = wire('pages')->get($editID);
+
+        // disable output formating – without this, the ajax request will not populate the field
+        $page->of(false);
+
+        // you could also insert a check to only do this with sepcific field names…
+        // $page->get($field->name)->add($page->children('template=DesiredTemplate')); // just specific templates
+        $page->get($field->name)->add($page->children);
+      }
+
+Now whenever there is a page-table field on your page, it gets populated with the children.
+
+[See Forum-Post](https://processwire.com/talk/topic/19634-a-hook-to-prefill-pagetable-fields-with-children-on-edit/?do=edit)

--- a/prefill PageTable fields with children on edit.md
+++ b/prefill PageTable fields with children on edit.md
@@ -1,3 +1,25 @@
+title: Prefill PageTable fields with children on edit.md
+
+----
+
+version: 1.0.1
+
+----
+
+authors: noelboss
+
+----
+
+tags: pages, fields
+
+----
+
+problem:
+Editing children is not very intuitive right away. The goal is to provide easy ordering and editing of children without loosing the page contect. Using a PageTable field to make this more intuitive, but children are not added automatically to this field.
+
+----
+
+Solution
 I use a PageTable field to make edits to children of pages more intuitive…
 
 To register the hooks, insert the following Snippet inside your init function in your module (or add it to your init.php file):
@@ -42,10 +64,15 @@ Then, add this hook method:
         $page->of(false);
 
         // you could also insert a check to only do this with sepcific field names…
-        // $page->get($field->name)->add($page->children('template=DesiredTemplate')); // just specific templates
-        $page->get($field->name)->add($page->children);
+        // $page->set($field->name, $page->children('template=DesiredTemplate')); // just specific templates
+        $page->set($field->name, $page->children);
+
       }
 
 Now whenever there is a page-table field on your page, it gets populated with the children.
 
+
+---
+resources:
 [See Forum-Post](https://processwire.com/talk/topic/19634-a-hook-to-prefill-pagetable-fields-with-children-on-edit/?do=edit)
+


### PR DESCRIPTION
A  hook to prefill PageTable fields with children on edit – see https://processwire.com/talk/topic/19634-a-hook-to-prefill-pagetable-fields-with-children-on-edit/?do=edit